### PR TITLE
Begin to address #11

### DIFF
--- a/R/build.R
+++ b/R/build.R
@@ -75,6 +75,10 @@ build.ardis <- function(x, layer=NULL, where=TRUE, ...) {
   # If the pre-build wasn't executed then execute it
   if (!'built_target' %in% ls(x)) {
     treatment_group_build(x)
+  }
+
+  # If header N's haven't been supplied, then construct them
+  if (!"header_n" %in% ls(x)) {
     x <- build_header_n(x)
   }
 

--- a/R/count.R
+++ b/R/count.R
@@ -402,11 +402,17 @@ process_count_denoms <- function(x) {
         ) %>%
       ungroup()
 
-    # Is this it? <-------
+    # Use cached header N's if they're available
     if (exists("cached_header_n")) {
       denoms_df_dist <- header_n %>%
         rename(distinct_n = n)
+
+      # If there was a treatment variable remap provided, add it
+      if (!is.null(header_treat_var)) {
+        by_join <- as_name(header_treat_var)
+      }
     } else {
+      # Calculate header N's from pop data if it wasn't available
       denoms_df_dist <- built_pop_data %>%
         filter(!!denom_where) %>%
         group_by(!!pop_treat_var) %>%
@@ -414,9 +420,10 @@ process_count_denoms <- function(x) {
           distinct_n = n_distinct(!!!distinct_by, !!pop_treat_var)
         ) %>%
         ungroup()
+
+      by_join <- as_name(pop_treat_var)
     }
 
-    by_join <- as_name(pop_treat_var)
     names(by_join) <- as_name(treat_var)
 
     denoms_df <- denoms_df_n %>%

--- a/R/count.R
+++ b/R/count.R
@@ -402,13 +402,19 @@ process_count_denoms <- function(x) {
         ) %>%
       ungroup()
 
-    denoms_df_dist <- built_pop_data %>%
-      filter(!!denom_where) %>%
-      group_by(!!pop_treat_var) %>%
-      summarize(
-        distinct_n = n_distinct(!!!distinct_by, !!pop_treat_var)
-      ) %>%
-      ungroup()
+    # Is this it? <-------
+    if (exists("cached_header_n")) {
+      denoms_df_dist <- header_n %>%
+        rename(distinct_n = n)
+    } else {
+      denoms_df_dist <- built_pop_data %>%
+        filter(!!denom_where) %>%
+        group_by(!!pop_treat_var) %>%
+        summarize(
+          distinct_n = n_distinct(!!!distinct_by, !!pop_treat_var)
+        ) %>%
+        ungroup()
+    }
 
     by_join <- as_name(pop_treat_var)
     names(by_join) <- as_name(treat_var)

--- a/R/count.R
+++ b/R/count.R
@@ -408,8 +408,11 @@ process_count_denoms <- function(x) {
         rename(distinct_n = n)
 
       # If there was a treatment variable remap provided, add it
-      if (!is.null(header_treat_var)) {
+      if (!quo_is_null(header_treat_var)) {
         by_join <- as_name(header_treat_var)
+      }
+      else {
+        by_join <- as_name(pop_treat_var)
       }
     } else {
       # Calculate header N's from pop data if it wasn't available

--- a/R/table_bindings.R
+++ b/R/table_bindings.R
@@ -62,7 +62,7 @@ set_header_n <- function(table, value) {
   assert_that(is.numeric(value$n),
               msg = "header_n argument must be named")
 
-  env_bind(table, header_n = value)
+  env_bind(table, header_n = value, cached_header_n = TRUE)
 
   table
 }

--- a/man/header_n.Rd
+++ b/man/header_n.Rd
@@ -8,24 +8,21 @@
 \usage{
 header_n(table)
 
-header_n(x) <- value
+header_n(table, x) <- value
 
-set_header_n(table, value)
+set_header_n(table, x, header_treat_var = NULL)
 }
 \arguments{
 \item{table}{A \code{ardis} object}
 
-\item{x}{A \code{ardis} object}
-
-\item{value}{A data.frame with columns with the treatment variable, column
+\item{x}{A data.frame with columns with the treatment variable, column
 variabes, and a variable with counts named 'n'.}
 
-\item{header_n}{A data.frame with columns with the treatment variable, column
-variabes, and a variable with counts named 'n'.}
+\item{header_treat_var}{The symbol name of the treatment variable in the header_n data frame. Provide unquoted}
 }
 \value{
 For \code{ardis_header_n} the header_n binding of the
-  \code{ardis} object. For \code{ardis_header_n<-} and
+  \code{ardis} object. For \code{header_n<-} and
   \code{set_ardis_header_n} the modified object.
 }
 \description{


### PR DESCRIPTION
This starts to address #11 by actually using `set_header_n()` to pull utilize the provided data frame for denominators. 

Example code:

```r
adsl <- haven::read_xpt("https://github.com/phuse-org/TestDataFactory/raw/main/Updated/TDF_ADaM/adsl.xpt")
adae <- haven::read_xpt("https://github.com/phuse-org/TestDataFactory/raw/main/Updated/TDF_ADaM/adae.xpt")

hd_n <- tibble::tribble(
  ~TRT01P, ~n,
  "Placebo", 96,
  "Xanomeline High Dose", 94,
  "Xanomeline Low Dose", 94
)

## Test for normal functionality with ADSL
t <- ardis(adsl, TRT01P, cols=SEX) %>%
  set_header_n(hd_n) %>%
  add_layer(
    group_count(RACE) %>% 
      set_distinct_by(USUBJID) %>% 
      set_summaries(
        vars(distinct_n, distinct_pct, distinct_total)
      )
  ) 

t %>% 
  build()

# Adverse events
t <- ardis(adae, TRTA) %>% 
  set_header_n(hd_n, TRT01P) %>%
  add_layer(
    group_count(vars(AEBODSYS, AEDECOD)) %>% 
      set_distinct_by(USUBJID) %>% 
      set_summaries(vars(distinct_n, distinct_pct, distinct_total))
  )

t %>% 
  build()

```